### PR TITLE
feat: Implement secure photo and note storage

### DIFF
--- a/app/src/main/res/layout/gallery_item.xml
+++ b/app/src/main/res/layout/gallery_item.xml
@@ -36,9 +36,9 @@
             android:layout_height="wrap_content"
             android:padding="8dp"
             android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-            android:layout_constraintEnd_toEndOf="parent"
-            android:layout_constraintStart_toStartOf="parent"
-            android:layout_constraintTop_toBottomOf="@+id/note_title" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/note_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
This commit implements a secure photo and note storage feature in the calculator app.

The main features are:
- A hidden gallery that can be accessed with a PIN.
- Encryption of photos and notes using AES-256-GCM.
- A secure key derivation function (PBKDF2 with HMAC-SHA256) to protect your PIN.
- A 3-attempt cooldown for PIN entry.
- The ability to add photos from the device.
- The ability to create, delete, and export galleries.
- Sorting of gallery items by name, date, and custom order.
- Security features such as returning to the calculator when the app loses focus or the phone is flipped.

This commit also fixes two build errors:
- A syntax error in `gallery_item.xml`.
- A manifest merger failure due to an incorrect `minSdk` version.